### PR TITLE
Use standard light blending for glass texture

### DIFF
--- a/scripts/perseus_custom.shader
+++ b/scripts/perseus_custom.shader
@@ -104,15 +104,9 @@ textures/perseus_custom/glass_02
 	surfaceparm trans
 
 	{
-		map textures/perseus_custom_src/scratchglass_d
-		blendfunc add
-		rgbGen const ( .1 .1 .1 )
-	}
-	{
-		map $lightmap
-		blendfunc gl_dst_color gl_src_alpha
-		rgbGen identity
-		tcGen lightmap
+		diffusemap textures/perseus_custom_src/scratchglass_d
+		blendfunc blend
+		alphaGen const .1
 	}
 }
 


### PR DESCRIPTION
This way it is 1 stage instead of 2, and doesn't make the stuff behind it appear brighter.

Before:
![380721550-564240d9-86d6-4170-9a06-ec12c8d30a89](https://github.com/user-attachments/assets/4b2cdbdb-5d67-4a0b-937d-527ff71ef173)
After:
![unvanquished_2024-10-31_225047_000](https://github.com/user-attachments/assets/8b87d87e-2a06-49f1-b592-8ba3fe9c6f5e)


(You can see it making stuff behind the door brighter where it's actually used in game too; it's just more obvious this way.)